### PR TITLE
Feature request: disable core dumps

### DIFF
--- a/palworld.service
+++ b/palworld.service
@@ -13,6 +13,7 @@ ExecStartPre=/home/steam/palworld-maintenance.sh
 ExecStart=/home/steam/.steam/steam/steamapps/common/PalServer/PalServer.sh -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS > /dev/null
 Restart=always
 RuntimeMaxSec=4h
+LimitCORE=0
 
 
 [Install]

--- a/palworld.service-no.steam
+++ b/palworld.service-no.steam
@@ -13,6 +13,7 @@ ExecStartPre=/home/steam/palworld-maintenance.sh
 ExecStart=/home/steam/Steam/steamapps/common/PalServer/PalServer.sh -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS > /dev/null
 Restart=always
 RuntimeMaxSec=4h
+LimitCORE=0
 
 
 [Install]


### PR DESCRIPTION
On an Ubuntu 20.04 system, a segmentation fault in PalServer caused a core dump file to be written out to `/var/cache/apport/coredump`. Since the server was using a huge amount of memory at the time, the core dump was correspondingly huge. This caused me to run out of disk space. Then, the server was unable to restart. While we cannot fix the segmentation fault, I think we could improve the crash handling.

Since there's no chance we'll be able to debug a core dump of this server, it seems kind of pointless to create them. However, I did not want to disable core dumps system wide. There may be other software on the server which *does* benefit from core dumps.

Fortunately, Linux has a feature to allow you to disable core dumps on a per-process basis. Each process has a set of limits called ulimits, and one of them governs the maximum space a process may use to create a core dump. Setting this to zero prevents that process or any child process of it from generating a core dump. SystemD also allows you to set this limit inside a service file. I am not sure what version of SystemD is required to support `LimitCORE`, but I think it's been supported for about nine years.

I've tested this change by applying it on my server and checking that `/proc/<pid>/limits` has the core dump limit.