### PR TITLE
Update README to better warn users

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ Stop the palworld server before restoring the backup
 systemctl stop palworld.service
 ```
 
-Delete the previous server data! ATTENTION! Make sure you have a backup before doing this! 
+Delete the previous server data
+> [!CAUTION]
+> Make sure you have a backup before doing this! 
 ```bash
 test -d /home/steam/.steam/steam/steamapps/common/PalServer/Pal/Saved && rm -rf /home/steam/.steam/steam/steamapps/common/PalServer/Pal/Saved
 ```


### PR DESCRIPTION
I noticed that the "Delete the previous server data" part did not have a "Caution" tag for the warning, which could lead some people to deleting their server data without noticing (if they don't read everything), this PR is to make sure there's a visual aid for the warning.