### PR TITLE
Feature: Backup on Server Shutdown

### DIFF
--- a/README-no.steam.md
+++ b/README-no.steam.md
@@ -3,7 +3,8 @@
 
 Follow this part of the tutorial after starting on the main one because your folders structure is not the same.
 
-Make sure you have a fresh Debian 12 server up and running with a SSH access.
+> [!IMPORTANT]
+> Make sure you have a fresh Debian 12 server up and running with a SSH access.
 
 Log in as steam:
 ```bash
@@ -28,13 +29,14 @@ cp DefaultPalWorldSettings.ini Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 
 ## Setup a service to automize the management of the server
 
-Make sure all the commands below are executed as root.
+> [!IMPORTANT]
+> Make sure all the commands below are executed as root.
 
 ### 1. Setup the maintenance script for server backups and updates (watch the videos for more details).
 
 Create the maintenance script, make it executable and give it the right user permissions:
 ```bash
-wget https://raw.githubusercontent.com/A1RM4X/HowTo-Palworld/main/palworld-maintenance.sh-no.steam -P /home/steam/ && mv /home/steam/palworld-maintenance.sh-no.steam /home/steam/palworld-maintenance.sh && chmod +x /home/steam/palworld-maintenance.sh && chown steam:steam /home/steam/palworld-maintenance.sh
+wget https://raw.githubusercontent.com/A1RM4X/HowTo-Palworld/main/palworld-backup.sh-no.steam -P /home/steam/ && mv /home/steam/palworld-backup.sh-no.steam /home/steam/palworld-backup.sh && chmod +x /home/steam/palworld-backup.sh && chown steam:steam /home/steam/palworld-backup.sh && wget https://raw.githubusercontent.com/A1RM4X/HowTo-Palworld/main/palworld-update.sh -P /home/steam/ && chmod +x /home/steam/palworld-update.sh && chown steam:steam /home/steam/palworld-update.sh
 ```
 
 Create the backup folder and give it the right permissions:
@@ -51,12 +53,17 @@ Enable and start the service file (watch the videos for more details):
 ```bash
 systemctl enable palworld.service && systemctl daemon-reload && systemctl start palworld.service
 ```
+
+### 2. Backing up and restoring server data localy
+
 Stop the palworld server before restoring the backup
 ```bash
 systemctl stop palworld.service
 ```
 
-Delete the previous server data! ATTENTION! Make sure you have a backup before doing this! 
+Delete the previous server data
+> [!CAUTION]
+> Make sure you have a backup before doing this! 
 ```bash
 test -d /home/steam/Steam/steamapps/common/PalServer/Pal/Saved && rm -rf /home/steam/Steam/steamapps/common/PalServer/Pal/Saved
 ```
@@ -68,7 +75,7 @@ tar -xzvf /home/steam/Palworld_backups/Palworld_MODIFY-DATE-HERE.tar.gz -C /
 
 Verify all went well
 ```bash
-test -d /home/steam/Steam/steamapps/common/PalServer/Pal/Saved && echo "RESTORATION SUCCESS"
+if test -d /home/steam/Steam/steamapps/common/PalServer/Pal/Saved ; then clear ; echo "RESTORATION SUCCESS" ; else clear ; echo "RESTORATION FAILED" ; fi
 ```
 ### [Back to the main Tutorial](https://github.com/A1RM4X/HowTo-Palworld/blob/main/README.md)
 

--- a/README.md
+++ b/README.md
@@ -19,19 +19,20 @@ More details videos below:
 # Tutorial
 ---
 
-Make sure you have a fresh Debian 12 / Ubuntu 23.10 server up and running with a SSH access.
+> [!IMPORTANT]
+> Make sure you have a fresh Debian 12 / Ubuntu 23.10 server up and running with a SSH access.
 
 Update and upgrade everything:
 ```bash
 apt update && apt dist-upgrade
 ```
 
-On Debian, install SteamCMD with all the dependencies:
+On **Debian**, install SteamCMD with all the dependencies:
 ```bash
 apt install software-properties-common && apt-add-repository non-free && dpkg --add-architecture i386 && apt update && apt install steamcmd
 ```
 
-On Ubuntu, install SteamCMD with all the dependencies:
+On **Ubuntu**, install SteamCMD with all the dependencies:
 ```bash
 apt install software-properties-common && apt-add-repository main universe restricted multiverse && dpkg --add-architecture i386 && apt update && apt install steamcmd
 ```
@@ -81,13 +82,14 @@ cp DefaultPalWorldSettings.ini Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
 
 ## Setup a service to automize the management of the server
 
-Make sure all the command below are executed as root.
+> [!IMPORTANT]
+> Make sure all the commands below are executed as root.
 
 ### 1. Setup the maintenance script for server backups and updates (watch the videos for more details).
 
 Create the maintenance script, make it executable and give it the right user permissions:
 ```bash
-wget https://raw.githubusercontent.com/A1RM4X/HowTo-Palworld/main/palworld-maintenance.sh -P /home/steam/ && chmod +x /home/steam/palworld-maintenance.sh && chown steam:steam /home/steam/palworld-maintenance.sh
+wget https://raw.githubusercontent.com/A1RM4X/HowTo-Palworld/main/palworld-update.sh -P /home/steam/ && chmod +x /home/steam/palworld-update.sh && chown steam:steam /home/steam/palworld-update.sh && wget https://raw.githubusercontent.com/A1RM4X/HowTo-Palworld/main/palworld-backup.sh -P /home/steam/ && chmod +x /home/steam/palworld-backup.sh && chown steam:steam /home/steam/palworld-backup.sh
 ```
 
 Create the backup folder and give it the right permissions:
@@ -152,9 +154,6 @@ Then follow the Backing up and restoring server data localy [here](https://githu
 Currently (as of this writing), if you want to move your save file from a windows server to a linux server (or vice versa), players will get assigned new `GUID` (global UIDs) upon connecting. So to get the old save file working, the files have to be edited, replacing old `GUID` with the new ones. 
 
 To fix this, please refer to [this](https://github.com/xNul/palworld-host-save-fix) repository.
-
-
-
 
 ### 3. No .steam folder on my debian server
 Some users reported not having the same folder structure on their Debian/Ubuntu installation. To fix the issue, use this [tutorial](https://github.com/A1RM4X/HowTo-Palworld/blob/main/README-no.steam.md).

--- a/palworld-backup.sh
+++ b/palworld-backup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+tar -czvf /home/steam/Palworld_backups/"Palworld_$(date '+%Y-%m-%d_%H-%M-%S').tar.gz" /home/steam/.steam/steam/steamapps/common/PalServer/Pal/Saved && find /home/steam/Palworld_backups/ -mtime +10 -type f -delete

--- a/palworld-backup.sh-no.steam
+++ b/palworld-backup.sh-no.steam
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+tar -czvf /home/steam/Palworld_backups/"Palworld_$(date '+%Y-%m-%d_%H-%M-%S').tar.gz" /home/steam/Steam/steamapps/common/PalServer/Pal/Saved && find /home/steam/Palworld_backups/ -mtime +10 -type f -delete

--- a/palworld-maintenance.sh
+++ b/palworld-maintenance.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/usr/games/steamcmd +login anonymous +app_update 2394010 validate +quit && tar -czvf /home/steam/Palworld_backups/"Palworld_$(date '+%Y-%m-%d_%H-%M-%S').tar.gz" /home/steam/.steam/steam/steamapps/common/PalServer/Pal/Saved && find /home/steam/Palworld_backups/ -mtime +10 -type f -delete

--- a/palworld-maintenance.sh-no.steam
+++ b/palworld-maintenance.sh-no.steam
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/usr/games/steamcmd +login anonymous +app_update 2394010 validate +quit && tar -czvf /home/steam/Palworld_backups/"Palworld_$(date '+%Y-%m-%d_%H-%M-%S').tar.gz" /home/steam/Steam/steamapps/common/PalServer/Pal/Saved && find /home/steam/Palworld_backups/ -mtime +10 -type f -delete

--- a/palworld-update.sh
+++ b/palworld-update.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/games/steamcmd +login anonymous +app_update 2394010 validate +quit

--- a/palworld.service
+++ b/palworld.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Palworld Dedicated Server by A1RM4X 0.3
+Description=Palworld Dedicated Server by A1RM4X 0.4
 Wants=network-online.target
 After=network-online.target
 
@@ -9,8 +9,9 @@ Group=steam
 Environment="templdpath=$LD_LIBRARY_PATH"
 Environment="LD_LIBRARY_PATH=/home/steam/:$LD_LIBRARY_PATH"
 Environment="SteamAppId=2394010"
-ExecStartPre=/home/steam/palworld-maintenance.sh
+ExecStartPre=/home/steam/palworld-update.sh
 ExecStart=/home/steam/.steam/steam/steamapps/common/PalServer/PalServer.sh -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS > /dev/null
+ExecStop=/home/steam/palworld-backup.sh
 Restart=always
 RuntimeMaxSec=4h
 LimitCORE=0

--- a/palworld.service
+++ b/palworld.service
@@ -11,7 +11,7 @@ Environment="LD_LIBRARY_PATH=/home/steam/:$LD_LIBRARY_PATH"
 Environment="SteamAppId=2394010"
 ExecStartPre=/home/steam/palworld-update.sh
 ExecStart=/home/steam/.steam/steam/steamapps/common/PalServer/PalServer.sh -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS > /dev/null
-ExecStop=/home/steam/palworld-backup.sh
+ExecStopPost=/home/steam/palworld-backup.sh
 Restart=always
 RuntimeMaxSec=4h
 LimitCORE=0

--- a/palworld.service-no.steam
+++ b/palworld.service-no.steam
@@ -11,7 +11,7 @@ Environment="LD_LIBRARY_PATH=/home/steam/:$LD_LIBRARY_PATH"
 Environment="SteamAppId=2394010"
 ExecStartPre=/home/steam/palworld-update.sh
 ExecStart=/home/steam/Steam/steamapps/common/PalServer/PalServer.sh -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS > /dev/null
-ExecStop=/home/steam/palworld-backup.sh
+ExecStopPost=/home/steam/palworld-backup.sh
 Restart=always
 RuntimeMaxSec=4h
 LimitCORE=0

--- a/palworld.service-no.steam
+++ b/palworld.service-no.steam
@@ -9,8 +9,9 @@ Group=steam
 Environment="templdpath=$LD_LIBRARY_PATH"
 Environment="LD_LIBRARY_PATH=/home/steam/:$LD_LIBRARY_PATH"
 Environment="SteamAppId=2394010"
-ExecStartPre=/home/steam/palworld-maintenance.sh
+ExecStartPre=/home/steam/palworld-update.sh
 ExecStart=/home/steam/Steam/steamapps/common/PalServer/PalServer.sh -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS > /dev/null
+ExecStop=/home/steam/palworld-backup.sh
 Restart=always
 RuntimeMaxSec=4h
 LimitCORE=0


### PR DESCRIPTION
> [!NOTE]
> Please merge #10 first

I feel like this is better because it saves the changes that have been made while the server was on, and in the case someone wants to do a rollback but still have a backup of the server as it was before the rollback.

I also updated the ``README-no.steam.md`` to include up-to-date script that weren't there, and a header that wasn't there.

I updated both ``README.md`` and ``README-no.steam.md`` to include the correct instructions for the new format.

I hope you like this update!